### PR TITLE
fix: sets the commitment level to confirmed

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -118,7 +118,7 @@ export const config: Config = ((): Config => {
 	// TODO: see what these options should be
 	// TODO: make these configurable with environment variables
 	const confirmOptions: ConfirmOptions = {
-		commitment: "finalized",
+		commitment: "confirmed",
 		preflightCommitment: "processed",
 	};
 	const MANAGEMENT_KEYS = [


### PR DESCRIPTION
The commitment level on the connection object was set to finalized
This caused the connection object to only fetch finalized data
Because this is really slow we now set it to confirmed which is the
next best thing.