### PR TITLE
fix: fixes principal display bug deal overview

### DIFF
--- a/src/react/components/DealOverview.tsx
+++ b/src/react/components/DealOverview.tsx
@@ -261,7 +261,6 @@ export const DealOverview = () => {
 						<p>The total amount of USDC borrowed</p>
 						<input
 							name="principal"
-							type="number"
 							readOnly={true}
 							disabled={true}
 							value={


### PR DESCRIPTION
principal was sometimes not shown because of the locale formatting
if locale added a , then feeding the value to an input type number
would not display it